### PR TITLE
Add trace spans limit

### DIFF
--- a/dtrace/config.go
+++ b/dtrace/config.go
@@ -12,4 +12,5 @@ type Config struct {
 	MyReplicaIndex    int      `yaml:"my_replica_index"`
 	MinTTL            int      `yaml:"min_ttl"`
 	MaxTTL            int      `yaml:"max_ttl"`
+	MaxSpansPerTrace  int      `yaml:"max_spans_per_trace"`
 }

--- a/dtrace/server.go
+++ b/dtrace/server.go
@@ -212,13 +212,13 @@ func loadBalancer(spansChannel chan *Span, toES chan *Document, config *Config) 
 				select {
 				case span, ok := <-ch:
 					if !ok {
-						traceMap = traceMap.Collect(0, 0, toES)
+						traceMap = traceMap.Collect(0, 0, config.MaxSpansPerTrace, toES)
 						return
 					}
 					traceMap.Put(span)
 				case <-timer.C:
 					timer = time.NewTimer(time.Second * 10)
-					traceMap = traceMap.Collect(time.Second*time.Duration(config.MinTTL), time.Second*time.Duration(config.MaxTTL), toES)
+					traceMap = traceMap.Collect(time.Second*time.Duration(config.MinTTL), time.Second*time.Duration(config.MaxTTL), config.MaxSpansPerTrace, toES)
 				}
 			}
 		}(ch)

--- a/main.go
+++ b/main.go
@@ -54,6 +54,7 @@ func getConfig(configLocation string) (*config, error) {
 			MyReplicaIndex:    0,
 			MinTTL:            10,
 			MaxTTL:            120,
+			MaxSpansPerTrace:  1000,
 		},
 	}
 

--- a/tests/suite_test.go
+++ b/tests/suite_test.go
@@ -101,7 +101,7 @@ var _ = Describe("DTrace", func() {
 
 			It("should not be collected too early", func() {
 				traceMap.Put(span)
-				traceMap = traceMap.Collect(time.Second*10, time.Second*10, make(chan *dtrace.Document))
+				traceMap = traceMap.Collect(time.Second*10, time.Second*10, 1000, make(chan *dtrace.Document))
 				Expect(len(traceMap)).To(Equal(1))
 			})
 		})
@@ -160,14 +160,20 @@ var _ = Describe("DTrace", func() {
 
 			It("should be wasted on timeout", func() {
 				traceMap.Put(span)
-				traceMap = traceMap.Collect(0, 0, toES)
+				traceMap = traceMap.Collect(0, 0, 1000, toES)
 				Expect(len(traceMap)).To(Equal(0))
 			})
 
 			It("should be waited for complete", func() {
 				traceMap.Put(span)
-				traceMap = traceMap.Collect(0, time.Minute, toES)
+				traceMap = traceMap.Collect(0, time.Minute, 1000, toES)
 				Expect(len(traceMap)).To(Equal(1))
+			})
+
+			It("should cleanup overflow trace", func() {
+				traceMap.Put(span)
+				traceMap = traceMap.Collect(0, time.Minute, 0, toES)
+				Expect(len(traceMap)).To(Equal(0))
 			})
 		})
 


### PR DESCRIPTION
In case if client implementation  is buggy and sends a lot of spans of never ended Trace, the configuration MaxSpansPerTrace limit should prevent memory leak.
